### PR TITLE
feat: add LLM-assisted invoice link extraction fallback

### DIFF
--- a/invoice_app/classifier.py
+++ b/invoice_app/classifier.py
@@ -57,3 +57,35 @@ Invoice:
     allowed = {"Work Equipment", "Insurance", "Travel", "Food", "Lifestyle", "Other"}
     return result if result in allowed else "Other"
 
+
+def extract_links_with_llm(subject: str, sender: str, links_context: str) -> list[str]:
+    prompt = f"""You are an email analysis assistant. Given the following email metadata and a list of links found in the email body, identify which URLs are most likely direct invoice or receipt PDF download links.
+
+Subject: {subject}
+From: {sender}
+
+Links found in email:
+{links_context}
+
+Return only the URLs that are most likely invoice/receipt PDF download links, one per line.
+If none of the links appear to be invoice download links, return "NONE".
+"""
+    try:
+        if USE_OPENAI and OPENAI_API_KEY:
+            client = openai.OpenAI(api_key=OPENAI_API_KEY)
+            response = client.chat.completions.create(
+                model=OPENAI_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=300,
+            )
+            result = response.choices[0].message.content.strip()
+        else:
+            response = ollama.chat(model=MODEL, messages=[{"role": "user", "content": prompt}])
+            result = response["message"]["content"].strip()
+
+        if result.upper() == "NONE":
+            return []
+        return [line.strip() for line in result.splitlines() if line.strip().startswith("http")]
+    except Exception:
+        return []
+

--- a/invoice_app/gmail_sync.py
+++ b/invoice_app/gmail_sync.py
@@ -199,6 +199,8 @@ def download_pdf_from_url(url: str, save_dir: str) -> Optional[str]:
     filename = os.path.basename(url.split("?")[0]) or "download.pdf"
     if not filename.lower().endswith(".pdf"):
         filename = f"{filename}.pdf"
+    if len(filename) > 120:
+        filename = f"{filename[:112]}.pdf"
     dest = _unique_file_path(os.path.join(save_dir, filename))
     with open(dest, "wb") as f:
         f.write(response.content)

--- a/invoice_app/gmail_sync.py
+++ b/invoice_app/gmail_sync.py
@@ -123,7 +123,27 @@ def download_pdf_attachments(
             yield dest
 
 
-def extract_pdf_links(full_message: dict) -> list[str]:
+def _extract_anchor_context(body_fragments: list[str], max_chars: int = 4000) -> str:
+    soup = BeautifulSoup("\n".join(body_fragments), "html.parser")
+    lines: list[str] = []
+    total = 0
+    for i, anchor in enumerate(soup.find_all("a"), 1):
+        href = (anchor.get("href") or "").strip()
+        if not href:
+            continue
+        text = (anchor.get_text(strip=True) or "")[:80]
+        parent_text = ""
+        if anchor.parent:
+            parent_text = (anchor.parent.get_text(strip=True) or "")[:50]
+        line = f"{i}. [{text}]({href}) -- context: \"{parent_text}\""
+        if total + len(line) > max_chars:
+            break
+        lines.append(line)
+        total += len(line) + 1
+    return "\n".join(lines)
+
+
+def extract_pdf_links(full_message: dict, *, use_llm_fallback: bool = False) -> list[str]:
     body_fragments: list[str] = []
     for part in full_message.get("payload", {}).get("parts", []):
         mime = part.get("mimeType")
@@ -143,6 +163,24 @@ def extract_pdf_links(full_message: dict) -> list[str]:
             cleaned = href.strip(">)].,;\"'")
             if cleaned not in urls:
                 urls.append(cleaned)
+
+    if not urls and use_llm_fallback:
+        context = _extract_anchor_context(body_fragments)
+        if context:
+            from invoice_app.classifier import extract_links_with_llm
+
+            subject = ""
+            sender = ""
+            for h in full_message.get("payload", {}).get("headers", []):
+                if h["name"].lower() == "subject":
+                    subject = h["value"]
+                if h["name"].lower() == "from":
+                    sender = h["value"]
+            llm_urls = extract_links_with_llm(subject, sender, context)
+            if llm_urls:
+                print(f"[i] LLM found {len(llm_urls)} link(s) for message")
+            urls.extend(llm_urls)
+
     return urls
 
 

--- a/main.py
+++ b/main.py
@@ -248,7 +248,7 @@ def run_sync_gmail(args) -> None:
             )
             statuses.append(status)
 
-        urls = gmail_sync.extract_pdf_links(full_message)
+        urls = gmail_sync.extract_pdf_links(full_message, use_llm_fallback=True)
         for url in urls:
             downloaded = gmail_sync.download_pdf_from_url(url, DOWNLOAD_DIR)
             if not downloaded:

--- a/scripts/tax-2024.sh
+++ b/scripts/tax-2024.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="${OLLAMA_MODEL:-mistral}"
+
+echo "=== 2024 Tax Declaration Workflow ==="
+echo ""
+
+# 1. Preflight
+echo "[1/6] Preflight checks..."
+if ! curl -sf localhost:11434 > /dev/null 2>&1; then
+    echo "ERROR: Ollama is not running. Start it with: ollama serve"
+    exit 1
+fi
+echo "  Ollama is running."
+
+if [ ! -f token.pickle ]; then
+    echo "ERROR: token.pickle not found. Run Gmail auth first."
+    exit 1
+fi
+echo "  Gmail token found."
+echo "  Model: $MODEL"
+echo ""
+
+# 2. Sync
+echo "[2/6] Syncing Gmail invoices for 2024..."
+python3 main.py sync-gmail --since 2024/01/01 --window-months 12 --apply-labels
+echo ""
+
+# 3. Review check
+echo "[3/6] Checking for items that need manual review..."
+python3 main.py find --year 2024 --status needs_review --open-gmail-link || true
+echo ""
+read -rp "Review the items above and handle any missing PDFs manually. Press Enter to continue..."
+echo ""
+
+# 4. Summary
+echo "[4/6] Summary of all 2024 invoices:"
+python3 main.py find --year 2024
+echo ""
+
+# 5. Export
+echo "[5/6] Exporting accountant packages for all months of 2024..."
+python3 main.py export-accountant --year 2024 --all-months
+echo ""
+
+# 6. Done
+echo "[6/6] Done!"
+echo "  Exports are in: Exports/2024/"
+echo "  Reminder: check any remaining 'needs_review' items before sending to your accountant."


### PR DESCRIPTION
## Summary
- Add `extract_links_with_llm` in `classifier.py` that uses OpenAI/Ollama to identify invoice PDF download URLs from email anchor tags
- Add `_extract_anchor_context` helper to build structured context from HTML anchors for LLM analysis
- `extract_pdf_links` now accepts `use_llm_fallback` flag; when heuristic extraction finds no links, it falls back to LLM-based link identification
- Enable LLM fallback by default in `sync-gmail` command

## Test plan
- [ ] Run `python3 main.py sync-gmail --window-months 1` and verify LLM fallback triggers for emails without obvious PDF links
- [ ] Verify heuristic-first behavior: emails with direct PDF links should not invoke the LLM
- [ ] Test with `USE_OPENAI=false` to confirm Ollama path works