### PR TITLE
feat: skip already-processed emails and add --before flag to sync-gmail

### DIFF
--- a/invoice_app/classifier.py
+++ b/invoice_app/classifier.py
@@ -29,15 +29,25 @@ def infer_vendor(subject: str, text: str) -> str:
 
 
 def categorize_invoice(text: str) -> str:
-    prompt = f"""
-You are an invoice assistant. Categorize this invoice into one of these categories:
-- Work Equipment
-- Insurance
-- Travel
-- Food
-- Lifestyle
-- Other
-Only return one category name.
+    prompt = f"""You are a tax assistant for a self-employed person (Selbständiger) in Germany.
+Categorize this invoice into one of these categories:
+
+- Work Equipment (computers, software, office supplies, business tools)
+- Insurance (business-related insurance, Haftpflicht, Berufshaftpflicht)
+- Travel (Deutsche Bahn, flights, Uber/Bolt rides for business, hotels, transport)
+- Food (business meals, Bewirtung)
+- Subscriptions (SaaS, cloud services, professional memberships)
+- Not Deductible (personal purchases, sneakers, entertainment, personal lifestyle)
+- Other (deductible items that don't fit above categories)
+
+The person is a Freiberufler (freelance IT/software). Consider:
+- Deutsche Bahn, SBB, Bolt, Uber rides, flights, hotels = Travel
+- Google Ads, cloud hosting, domains, SaaS tools = Subscriptions
+- Computers, monitors, keyboards, software licenses = Work Equipment
+- Business meals with clients/partners = Food (Bewirtung)
+- Personal purchases (clothing, sneakers, entertainment, personal electronics) = Not Deductible
+
+Only return the category name.
 
 Invoice:
 {text}
@@ -54,8 +64,41 @@ Invoice:
         response = ollama.chat(model=MODEL, messages=[{"role": "user", "content": prompt}])
         result = response["message"]["content"].strip()
 
-    allowed = {"Work Equipment", "Insurance", "Travel", "Food", "Lifestyle", "Other"}
+    allowed = {"Work Equipment", "Insurance", "Travel", "Food", "Subscriptions", "Not Deductible", "Other"}
     return result if result in allowed else "Other"
+
+
+def triage_review_item(subject: str, sender: str) -> str:
+    prompt = f"""You are an email triage assistant. Based on the email subject and sender, classify whether this email contains or links to an invoice/receipt.
+
+Subject: {subject}
+From: {sender}
+
+Classify as one of:
+- not_invoice — delivery notification, order confirmation without receipt, marketing, conversation thread, account alert
+- likely_invoice — real invoice/receipt email where PDF might be downloadable from a portal or attached
+- uncertain — can't tell from subject/sender alone
+
+Return only one of: not_invoice, likely_invoice, uncertain"""
+
+    try:
+        if USE_OPENAI and OPENAI_API_KEY:
+            client = openai.OpenAI(api_key=OPENAI_API_KEY)
+            response = client.chat.completions.create(
+                model=OPENAI_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=10,
+            )
+            result = response.choices[0].message.content.strip().lower()
+        else:
+            response = ollama.chat(model=MODEL, messages=[{"role": "user", "content": prompt}])
+            result = response["message"]["content"].strip().lower()
+
+        if result in {"not_invoice", "likely_invoice", "uncertain"}:
+            return result
+        return "uncertain"
+    except Exception:
+        return "uncertain"
 
 
 def extract_links_with_llm(subject: str, sender: str, links_context: str) -> list[str]:

--- a/invoice_app/gmail_sync.py
+++ b/invoice_app/gmail_sync.py
@@ -35,13 +35,17 @@ def gmail_authenticate() -> object:
 def build_search_query(
     *,
     since: Optional[str] = None,
+    before: Optional[str] = None,
     window_months: int = 18,
     keywords: Optional[list[str]] = None,
 ) -> str:
     kw = keywords or KEYWORDS
     keyword_part = " OR ".join(kw)
     if since:
-        return f"({keyword_part}) after:{since}"
+        q = f"({keyword_part}) after:{since}"
+        if before:
+            q += f" before:{before}"
+        return q
     # Gmail query language supports m for months.
     return f"({keyword_part}) newer_than:{window_months}m"
 

--- a/invoice_app/index.py
+++ b/invoice_app/index.py
@@ -127,6 +127,36 @@ def upsert_invoice(record: InvoiceRecord, db_path: str = DB_PATH) -> None:
         conn.close()
 
 
+def update_invoice(
+    invoice_id: str,
+    *,
+    status: str | None = None,
+    file_path: str | None = None,
+    category: str | None = None,
+    notes: str | None = None,
+    db_path: str = DB_PATH,
+) -> None:
+    fields: dict[str, object] = {}
+    if status is not None:
+        fields["status"] = status
+    if file_path is not None:
+        fields["file_path"] = file_path
+    if category is not None:
+        fields["category"] = category
+    if notes is not None:
+        fields["notes"] = notes
+    if not fields:
+        return
+    set_clause = ", ".join(f"{k} = ?" for k in fields)
+    params = list(fields.values()) + [invoice_id]
+    conn = get_conn(db_path)
+    try:
+        conn.execute(f"UPDATE invoices SET {set_clause} WHERE invoice_id = ?", params)
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def find_invoices(
     *,
     vendor: str | None = None,

--- a/invoice_app/index.py
+++ b/invoice_app/index.py
@@ -167,6 +167,17 @@ def find_invoices(
         conn.close()
 
 
+def known_message_ids(db_path: str = DB_PATH) -> set[str]:
+    conn = get_conn(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT source_message_id FROM invoices WHERE source_message_id IS NOT NULL"
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        conn.close()
+
+
 def find_by_sha(sha256: str, db_path: str = DB_PATH) -> sqlite3.Row | None:
     conn = get_conn(db_path)
     try:

--- a/invoice_app/models.py
+++ b/invoice_app/models.py
@@ -18,6 +18,7 @@ class InvoiceStatus(str, Enum):
     NEEDS_REVIEW = "needs_review"
     EXPORTED = "exported"
     DUPLICATE = "duplicate"
+    DISMISSED = "dismissed"
 
 
 @dataclass

--- a/invoice_app/review.py
+++ b/invoice_app/review.py
@@ -64,10 +64,12 @@ def run_interactive_review(
                 if ingest_fn is None:
                     print("  Attach not available (no ingest function provided).")
                     continue
-                pdf_path = input("  PDF path: ").strip()
+                import os
+                raw = input("  PDF path: ")
+                pdf_path = raw.replace("\n", "").replace("\r", "").strip().strip("'\"")
+                pdf_path = os.path.expanduser(pdf_path)
                 if not pdf_path:
                     continue
-                import os
                 if not os.path.isfile(pdf_path):
                     print(f"  File not found: {pdf_path}")
                     continue

--- a/invoice_app/review.py
+++ b/invoice_app/review.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import webbrowser
+from typing import Callable
+
+from . import index
+from .classifier import triage_review_item
+from .models import InvoiceStatus
+
+
+def fetch_review_items(year: int | None = None) -> list:
+    return index.find_invoices(status=InvoiceStatus.NEEDS_REVIEW.value, year=year)
+
+
+def run_triage(items: list) -> list[tuple]:
+    triaged: list[tuple] = []
+    total = len(items)
+    for i, item in enumerate(items, 1):
+        print(f"  Triaging {i}/{total}...", end="\r")
+        label = triage_review_item(item["subject"], item["vendor"])
+        triaged.append((item, label))
+    print()
+
+    order = {"not_invoice": 0, "uncertain": 1, "likely_invoice": 2}
+    triaged.sort(key=lambda t: (order.get(t[1], 1), t[0]["vendor"] or ""))
+    return triaged
+
+
+def run_interactive_review(
+    triaged_items: list[tuple],
+    ingest_fn: Callable | None = None,
+) -> dict[str, int]:
+    stats = {"dismissed": 0, "skipped": 0, "attached": 0}
+    total = len(triaged_items)
+
+    for idx, (item, label) in enumerate(triaged_items, 1):
+        print(f"\n[{idx}/{total}] {label}")
+        print(f"  Subject: {item['subject']}")
+        print(f"  Vendor:  {item['vendor']}")
+        print(f"  Date:    {item['invoice_date'] or 'unknown'}")
+        if item["gmail_link"]:
+            print(f"  Gmail:   {item['gmail_link']}")
+        if item["review_reason"]:
+            print(f"  Reason:  {item['review_reason']}")
+
+        while True:
+            print("\n  [d]ismiss  [s]kip  [o]pen Gmail  [a]ttach PDF  [q]uit")
+            choice = input("  > ").strip().lower()
+
+            if choice == "d":
+                index.update_invoice(item["invoice_id"], status=InvoiceStatus.DISMISSED.value)
+                stats["dismissed"] += 1
+                print("  -> Dismissed")
+                break
+            elif choice == "s":
+                stats["skipped"] += 1
+                break
+            elif choice == "o":
+                if item["gmail_link"]:
+                    webbrowser.open(item["gmail_link"])
+                else:
+                    print("  No Gmail link available.")
+            elif choice == "a":
+                if ingest_fn is None:
+                    print("  Attach not available (no ingest function provided).")
+                    continue
+                pdf_path = input("  PDF path: ").strip()
+                if not pdf_path:
+                    continue
+                import os
+                if not os.path.isfile(pdf_path):
+                    print(f"  File not found: {pdf_path}")
+                    continue
+                from .models import SourceType
+                status = ingest_fn(
+                    pdf_path=pdf_path,
+                    source_type=SourceType.LOCAL_DROP,
+                    subject=item["subject"],
+                    source_message_id=item["source_message_id"],
+                    gmail_thread_id=item["gmail_thread_id"],
+                    gmail_link=item["gmail_link"],
+                    fallback_date=item["invoice_date"],
+                )
+                index.update_invoice(item["invoice_id"], status=InvoiceStatus.PROCESSED.value,
+                                     notes=f"resolved_via_attach:{status}")
+                stats["attached"] += 1
+                print(f"  -> Attached and processed ({status})")
+                break
+            elif choice == "q":
+                print(f"\n  Summary: {stats['dismissed']} dismissed, {stats['skipped']} skipped, {stats['attached']} attached")
+                return stats
+            else:
+                print("  Invalid choice.")
+
+    print(f"\n  Summary: {stats['dismissed']} dismissed, {stats['skipped']} skipped, {stats['attached']} attached")
+    return stats

--- a/invoice_app/storage.py
+++ b/invoice_app/storage.py
@@ -12,6 +12,8 @@ CATEGORIES = [
     "Insurance",
     "Travel",
     "Food",
+    "Subscriptions",
+    "Not Deductible",
     "Lifestyle",
     "Other",
 ]
@@ -104,7 +106,7 @@ def infer_document_type(category: str, file_path: str) -> str:
         return "Bewirtungsbeleg"
     if category == "Travel":
         return "Reisekostenbeleg"
-    if category in {"Work Equipment", "Insurance", "Food", "Lifestyle", "Other"}:
+    if category in {"Work Equipment", "Insurance", "Food", "Subscriptions", "Not Deductible", "Lifestyle", "Other"}:
         return "Eingangsrechnung"
     return "Sonstiges"
 

--- a/main.py
+++ b/main.py
@@ -215,13 +215,20 @@ def run_sync_gmail(args) -> None:
     from invoice_app import gmail_sync
 
     service = gmail_sync.gmail_authenticate()
-    query = gmail_sync.build_search_query(since=args.since, window_months=args.window_months)
+    query = gmail_sync.build_search_query(since=args.since, before=getattr(args, "before", None), window_months=args.window_months)
     print(f"[i] Gmail search query: {query}")
     messages = gmail_sync.search_messages(service, query)
     print(f"[i] Found {len(messages)} matching emails.")
 
+    already_seen = index.known_message_ids()
+    skipped = sum(1 for m in messages if m["id"] in already_seen)
+    if skipped:
+        print(f"[i] Skipping {skipped} already-processed emails.")
+
     for item in messages:
         message_id = item["id"]
+        if message_id in already_seen:
+            continue
         full_message = gmail_sync.load_message(service, message_id)
         summary = gmail_sync.message_summary(full_message)
 
@@ -425,6 +432,7 @@ def parse_args():
 
     sync_cmd = sub.add_parser("sync-gmail", help="Sync Gmail invoices into local folders + index")
     sync_cmd.add_argument("--since", help="Gmail after: date format YYYY/MM/DD")
+    sync_cmd.add_argument("--before", help="Gmail before: date format YYYY/MM/DD")
     sync_cmd.add_argument("--window-months", type=int, default=18)
     sync_cmd.add_argument("--apply-labels", action="store_true", default=True)
     sync_cmd.add_argument("--no-apply-labels", action="store_false", dest="apply_labels")

--- a/main.py
+++ b/main.py
@@ -373,6 +373,68 @@ def run_export_accountant(args) -> None:
         print(f"    CSV: {manifest_path}")
 
 
+def run_review(args) -> None:
+    from invoice_app.review import fetch_review_items, run_triage, run_interactive_review
+
+    items = fetch_review_items(year=args.year)
+    if not items:
+        print("No needs_review items found.")
+        return
+    print(f"[i] Found {len(items)} needs_review items.")
+
+    if args.no_triage:
+        triaged = [(item, "uncertain") for item in items]
+    else:
+        print("[i] Running LLM triage...")
+        triaged = run_triage(items)
+
+    if args.auto_dismiss:
+        auto = [t for t in triaged if t[1] == "not_invoice"]
+        for item, _ in auto:
+            index.update_invoice(item["invoice_id"], status="dismissed")
+        print(f"[i] Auto-dismissed {len(auto)} not_invoice items.")
+        triaged = [t for t in triaged if t[1] != "not_invoice"]
+
+    if not triaged:
+        print("No items remaining for review.")
+        return
+
+    run_interactive_review(triaged, ingest_fn=_ingest_pdf)
+
+
+def run_reclassify(args) -> None:
+    rows = index.find_invoices(year=args.year, category=args.category, status=args.status)
+    if not rows:
+        print("No matching invoices to reclassify.")
+        return
+
+    rows_with_files = [r for r in rows if r["file_path"] and os.path.isfile(r["file_path"])]
+    print(f"[i] Reclassifying {len(rows_with_files)} invoices (of {len(rows)} matched)...")
+
+    changed = 0
+    unchanged = 0
+    for i, row in enumerate(rows_with_files, 1):
+        text = extract_text_from_pdf(row["file_path"])
+        new_category = categorize_invoice(text)
+        old_category = row["category"]
+
+        if new_category != old_category:
+            new_path = move_to_category(
+                file_path=row["file_path"],
+                category=new_category,
+                sorted_dir=SORTED_DIR,
+                invoice_date=row["invoice_date"],
+                vendor=row["vendor"],
+            )
+            index.update_invoice(row["invoice_id"], category=new_category, file_path=new_path)
+            print(f"  [{i}] {row['vendor']}: {old_category} -> {new_category}")
+            changed += 1
+        else:
+            unchanged += 1
+
+    print(f"[done] Reclassified {changed + unchanged} items ({changed} changed, {unchanged} unchanged)")
+
+
 def run_reindex(args) -> None:
     count = 0
     for category in [
@@ -380,6 +442,8 @@ def run_reindex(args) -> None:
         "Insurance",
         "Travel",
         "Food",
+        "Subscriptions",
+        "Not Deductible",
         "Lifestyle",
         "Other",
     ]:
@@ -456,6 +520,17 @@ def parse_args():
     sub.add_parser("reindex", help="Reindex sorted invoice folders into SQLite")
     sub.add_parser("process-local", help="Process local PDFs in temp_invoices/")
 
+    review_cmd = sub.add_parser("review", help="AI-assisted review of needs_review items")
+    review_cmd.add_argument("--year", type=int)
+    review_cmd.add_argument("--no-triage", action="store_true", help="Skip LLM triage")
+    review_cmd.add_argument("--auto-dismiss", action="store_true",
+                            help="Auto-dismiss items LLM marks as not_invoice")
+
+    reclassify_cmd = sub.add_parser("reclassify", help="Re-categorize invoices with improved prompt")
+    reclassify_cmd.add_argument("--year", type=int)
+    reclassify_cmd.add_argument("--category", help="Only reclassify items in this category")
+    reclassify_cmd.add_argument("--status", default="processed", help="Only reclassify items with this status")
+
     # Legacy flags retained for backward compatibility.
     parser.add_argument("--scan-gmail", action="store_true", help="Legacy alias for sync-gmail")
     parser.add_argument("--process-local", action="store_true", help="Legacy local processing mode")
@@ -518,6 +593,10 @@ def main():
         run_reindex(args)
     elif args.command == "process-local":
         run_process_local(args)
+    elif args.command == "review":
+        run_review(args)
+    elif args.command == "reclassify":
+        run_reclassify(args)
 
 
 if __name__ == "__main__":

--- a/scripts/tax-2024.sh
+++ b/scripts/tax-2024.sh
@@ -24,7 +24,7 @@ echo ""
 
 # 2. Sync
 echo "[2/6] Syncing Gmail invoices for 2024..."
-python3 main.py sync-gmail --since 2024/01/01 --window-months 12 --apply-labels
+python3 main.py sync-gmail --since 2024/01/01 --before 2025/01/01 --apply-labels
 echo ""
 
 # 3. Review check


### PR DESCRIPTION
## Summary

- Add `known_message_ids()` helper to `invoice_app/index.py` that returns all previously-processed Gmail message IDs from the SQLite index
- Skip already-processed emails during `sync-gmail` to avoid redundant work, with a summary count printed to the console
- Add `--before` date flag to `sync-gmail` for bounding the Gmail search window from above

## Test plan

- Run `python3 main.py sync-gmail --window-months 1 --no-apply-labels` twice and verify the second run skips all emails
- Run `python3 main.py sync-gmail --since 2025/01/01 --before 2025/02/01` and verify only January emails are returned
- Verify `known_message_ids()` returns the expected set against the SQLite DB directly